### PR TITLE
Add an option to specify token storage method via module settings

### DIFF
--- a/angular_token_auth.js
+++ b/angular_token_auth.js
@@ -12,6 +12,7 @@
         LOGOUT_REDIRECT_URL: '/logout/',
         AUTH_HEADER_PREFIX: 'Token',
         ALLOWED_HOSTS: [],
+        STORAGE_METHOD: 'auto'
         COOKIE_PATH: null
     });
 
@@ -297,13 +298,20 @@
             }
         };
 
-        //use cookies if available, otherwise try localstorage
-        if (storageMethods['cookie'].test() === true) {
+        if (MODULE_SETTINGS.STORAGE_METHOD === 'cookie') {
             return storageMethods['cookie'];
-        } else if (storageMethods['localStorage'].test()) {
+        } else if (MODULE_SETTINGS.STORAGE_METHOD === 'localstorage') {
             return storageMethods['localStorage'];
         } else {
-            return storageMethods['noSupport'];
+            // Use the default 'auto' method for determining storage type
+            // Use cookies if available, otherwise try localstorage
+            if (storageMethods['cookie'].test() === true) {
+                return storageMethods['cookie'];
+            } else if (storageMethods['localStorage'].test()) {
+                return storageMethods['localStorage'];
+            } else {
+                return storageMethods['noSupport'];
+            }
         }
 
     }]);

--- a/angular_token_auth.js
+++ b/angular_token_auth.js
@@ -12,7 +12,7 @@
         LOGOUT_REDIRECT_URL: '/logout/',
         AUTH_HEADER_PREFIX: 'Token',
         ALLOWED_HOSTS: [],
-        STORAGE_METHOD: 'auto'
+        STORAGE_METHOD: 'auto',
         COOKIE_PATH: null
     });
 

--- a/angular_token_auth.js
+++ b/angular_token_auth.js
@@ -301,8 +301,9 @@
             }
         };
 
-        if (storageMethods[MODULE_SETTINGS.STORAGE_METHOD]) {
-            return storageMethods[MODULE_SETTINGS.STORAGE_METHOD];
+        var method = storageMethods[MODULE_SETTINGS.STORAGE_METHOD];
+        if (method && method.test()) {
+            return method;
         } else {
             // Either we had no specified storage method, or we couldn't
             //  find the requested one, so try to auto-detect
@@ -315,6 +316,7 @@
                 return storageMethods['noSupport'];
             }
         }
+        
 
     }]);
 

--- a/angular_token_auth.js
+++ b/angular_token_auth.js
@@ -299,7 +299,7 @@
             }
         };
 
-        if (MODULE_SETTINGS.STORAGE_METHOD && storageMethods[MODULE_SETTINGS.STORAGE_METHOD]) {
+        if (storageMethods[MODULE_SETTINGS.STORAGE_METHOD]) {
             return storageMethods[MODULE_SETTINGS.STORAGE_METHOD];
         } else {
             // Either we had no specified storage method, or we couldn't

--- a/angular_token_auth.js
+++ b/angular_token_auth.js
@@ -13,8 +13,10 @@
         AUTH_HEADER_PREFIX: 'Token',
         ALLOWED_HOSTS: [],
         COOKIE_PATH: null
-        // Optional settings examples:
-        // STORAGE_METHOD: 'localstorage',
+        // Optional settings:
+        // STORAGE_METHOD: value
+        // value should be a string corresponding to a key of a storageMethod in 
+        //  authStorageFactory. Allowed values: localstorage, cookie
     });
 
     auth.config(['$routeProvider', 'TOKEN_AUTH', 'PROJECT_SETTINGS', function ($routeProvider, TOKEN_AUTH, PROJECT_SETTINGS) {

--- a/angular_token_auth.js
+++ b/angular_token_auth.js
@@ -12,8 +12,9 @@
         LOGOUT_REDIRECT_URL: '/logout/',
         AUTH_HEADER_PREFIX: 'Token',
         ALLOWED_HOSTS: [],
-        STORAGE_METHOD: 'auto',
         COOKIE_PATH: null
+        // Optional settings examples:
+        // STORAGE_METHOD: 'localstorage',
     });
 
     auth.config(['$routeProvider', 'TOKEN_AUTH', 'PROJECT_SETTINGS', function ($routeProvider, TOKEN_AUTH, PROJECT_SETTINGS) {
@@ -298,12 +299,11 @@
             }
         };
 
-        if (MODULE_SETTINGS.STORAGE_METHOD === 'cookie') {
-            return storageMethods['cookie'];
-        } else if (MODULE_SETTINGS.STORAGE_METHOD === 'localstorage') {
-            return storageMethods['localStorage'];
+        if (MODULE_SETTINGS.STORAGE_METHOD && storageMethods[MODULE_SETTINGS.STORAGE_METHOD]) {
+            return storageMethods[MODULE_SETTINGS.STORAGE_METHOD];
         } else {
-            // Use the default 'auto' method for determining storage type
+            // Either we had no specified storage method, or we couldn't
+            //  find the requested one, so try to auto-detect
             // Use cookies if available, otherwise try localstorage
             if (storageMethods['cookie'].test() === true) {
                 return storageMethods['cookie'];

--- a/angular_token_auth.js
+++ b/angular_token_auth.js
@@ -14,9 +14,9 @@
         ALLOWED_HOSTS: [],
         COOKIE_PATH: null
         // Optional settings:
-        // STORAGE_METHOD: value
-        // value should be a string corresponding to a key of a storageMethod in 
-        //  authStorageFactory. Allowed values: localstorage, cookie
+        // STORAGE_METHOD: 'cookie'
+        // STORAGE_METHOD: 'localStorage'
+        // STORAGE_METHOD: 'noSupport'
     });
 
     auth.config(['$routeProvider', 'TOKEN_AUTH', 'PROJECT_SETTINGS', function ($routeProvider, TOKEN_AUTH, PROJECT_SETTINGS) {


### PR DESCRIPTION
This allows us to specify local storage for cordova-based apps which don't auto-detect cookie storage correctly